### PR TITLE
fix: address review feedback for local classes migration

### DIFF
--- a/scripts/seed-object.ts
+++ b/scripts/seed-object.ts
@@ -1,6 +1,49 @@
 import 'dotenv/config';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { supabaseAdmin } from '@/lib/supabase/server';
 import { mintToken } from '@/lib/id';
+
+async function findOrCreateLocalClass(
+  db: SupabaseClient,
+  classification: { id: string; label?: string | null; label_ja?: string | null }
+): Promise<string> {
+  const { data: existingLinks, error: linkQueryError } = await db
+    .from('local_class_links')
+    .select('local_class_id')
+    .eq('classification_id', classification.id)
+    .limit(1);
+  if (linkQueryError) throw linkQueryError;
+
+  const existingId: string | null = existingLinks?.[0]?.local_class_id ?? null;
+  if (existingId) return existingId;
+
+  const classToken = mintToken();
+  const label_en = classification.label ?? 'Untitled';
+  const label_ja = classification.label_ja ?? null;
+  const { data: createdClass, error: createClassError } = await db
+    .from('local_classes')
+    .insert({ token: classToken, label_en, label_ja, description: 'Seeded class' })
+    .select('id')
+    .single();
+  if (createClassError || !createdClass)
+    throw createClassError || new Error('Local class create failed');
+
+  const createdId = (createdClass as { id?: unknown })?.id;
+  if (typeof createdId !== 'string') throw new Error('Unexpected local_classes.id type');
+
+  const { error: linkInsertError } = await db
+    .from('local_class_links')
+    .upsert({ classification_id: classification.id, local_class_id: createdId });
+  if (linkInsertError) throw linkInsertError;
+
+  const { error: setPreferredError } = await db
+    .from('local_classes')
+    .update({ preferred_classification_id: classification.id })
+    .eq('id', createdId);
+  if (setPreferredError) throw setPreferredError;
+
+  return createdId;
+}
 
 async function main() {
   const token = mintToken(12);
@@ -14,7 +57,6 @@ async function main() {
       title: 'Black Raku chawan',
       local_number: 'ITO-2025-001',
       visibility: 'public',
-      summary: 'A black Raku tea bowl.',
     })
     .select()
     .single();
@@ -31,39 +73,11 @@ async function main() {
     throw upsertClassificationError || new Error('Classification upsert failed');
 
   // 3) Find or create a Local Class for this concept
-  // Try: does a local class already link to this classification?
-  const { data: existingLinks, error: linkQueryError } = await db
-    .from('local_class_links')
-    .select('local_class_id')
-    .eq('classification_id', classification.id)
-    .limit(1);
-  if (linkQueryError) throw linkQueryError;
-
-  let localClassId: string | null = existingLinks?.[0]?.local_class_id ?? null;
-  if (!localClassId) {
-    // Create a new Local Class
-    const classToken = mintToken();
-    const { data: createdClass, error: createClassError } = await db
-      .from('local_classes')
-      .insert({ token: classToken, label_en: 'Tea bowls', label_ja: '茶碗', description: 'Seeded class' })
-      .select('id')
-      .single();
-    if (createClassError || !createdClass)
-      throw createClassError || new Error('Local class create failed');
-    localClassId = String((createdClass as any).id);
-
-    // Link the Local Class to the classification and set preferred
-    const { error: linkInsertError } = await db
-      .from('local_class_links')
-      .upsert({ classification_id: classification.id, local_class_id: localClassId });
-    if (linkInsertError) throw linkInsertError;
-
-    const { error: setPreferredError } = await db
-      .from('local_classes')
-      .update({ preferred_classification_id: classification.id })
-      .eq('id', localClassId);
-    if (setPreferredError) throw setPreferredError;
-  }
+  const localClassId = await findOrCreateLocalClass(db, {
+    id: classification.id,
+    label: classification.label,
+    label_ja: classification.label_ja,
+  });
 
   // 4) Attach the Local Class to the object
   const { error: updateObjectError } = await db


### PR DESCRIPTION
Fixes #36.\n\n- Remove deprecated summary field from seed insert\n- Replace 'as any' with typed path for local_classes.id\n- Extract findOrCreateLocalClass helper for clarity\n\nStacked on top of PR #35 (dev -> main).