### PR TITLE
UI Sans Fonts + Item Link Fix: finalize polish, link targets, and global clickable styles

### DIFF
--- a/app/components/NavBarClient.tsx
+++ b/app/components/NavBarClient.tsx
@@ -84,7 +84,7 @@ export default function NavBarClient({ isLoggedIn, isAdmin }: { isLoggedIn: bool
         Menu
       </button>
       <a className="font-medium text-sm hidden md:inline" href="/">Home</a>
-      <a className="font-medium text-sm hidden md:inline" href="/lookup">Lookup</a>
+      <a className="hidden md:inline btn btn-outline text-sm" href="/lookup" role="button">Lookup</a>
 
       <div className="relative hidden md:block">
         <input
@@ -150,7 +150,7 @@ export default function NavBarClient({ isLoggedIn, isAdmin }: { isLoggedIn: bool
           </div>
         </details>
       ) : (
-        <a className="font-medium text-sm hidden md:inline" href="/login">Login</a>
+        <a className="hidden md:inline btn btn-primary text-sm" href="/login" role="button">Login</a>
       )}
 
       {mobileOpen ? (

--- a/app/globals.css
+++ b/app/globals.css
@@ -82,6 +82,9 @@ html, body { padding: 0; margin: 0 }
 
 /* Global clickable link and button affordances */
 @layer components {
+  a {
+    @apply underline underline-offset-4 text-primary hover:no-underline;
+  }
   .btn {
     @apply inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring;
     @apply px-4 py-2;

--- a/app/globals.css
+++ b/app/globals.css
@@ -79,3 +79,20 @@ html, body { padding: 0; margin: 0 }
     @apply bg-background text-foreground;
   }
 }
+
+/* Global clickable link and button affordances */
+@layer components {
+  .btn {
+    @apply inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring;
+    @apply px-4 py-2;
+  }
+  .btn-primary {
+    @apply bg-primary text-primary-foreground hover:bg-primary/90;
+  }
+  .btn-outline {
+    @apply border border-input bg-background hover:bg-accent hover:text-accent-foreground;
+  }
+  .link {
+    @apply text-primary underline underline-offset-4 hover:no-underline;
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,20 +15,21 @@ export default async function HomePage() {
 
   return (
     <main>
-      <section className="prose">
-        <h1>Chanoyu Collections</h1>
-        <h2 lang="ja">茶道の記録と共有</h2>
+      <section className="max-w-3xl mx-auto px-4 py-10">
+        <h1 className="text-2xl font-semibold">Chanoyu Collections</h1>
+        <h2 className="text-base text-muted-foreground" lang="ja">茶道の記録と共有</h2>
 
-        <p>
-          Preserve and share tea ceremony knowledge. Browse public information or sign in to manage private
-          records. 茶会（茶会／chakai）、茶室、道具、メディアを相互に関連付けて記録します。
+        <p className="mt-4 text-base leading-relaxed">
+          Preserve and share tea ceremony knowledge. Browse public information or sign in to manage private records.
+        </p>
+        <p className="text-base leading-relaxed">
+          茶会（茶会／chakai）、茶室、道具、メディアを相互に関連付けて記録します。
         </p>
 
-        <h3>Explore</h3>
-        <ul>
-          <li><a href="/lookup">Browse Lookup</a></li>
-          <li><a href="/login">Log in</a></li>
-        </ul>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <a href="/lookup" className="btn btn-primary" role="button">Browse Lookup</a>
+          <a href="/login" className="btn btn-outline" role="button">Log in</a>
+        </div>
       </section>
     </main>
   );


### PR DESCRIPTION
# UI Sans Fonts + Item Link Fix: finalize polish, link targets, and global clickable styles

This PR completes and hardens the work scoped in the UI Sans Fonts + Item Link Fix spec, addresses review feedback, and improves logged‑out UX.

## Summary
- Enforce sans-serif UI fonts and unify color tokens to shadcn.
- Ensure item name links to public route and update admin list links.
- Improve type safety, error logging, and search loading state.
- Fix CI/Actions issues and make `/objects` dynamic to avoid missing envs at build time.
- Polish the logged‑out index and add site‑wide clickable affordances.

## Changes
- Design system
  - Standardize colors on shadcn tokens in `app/globals.css` and map legacy aliases in `tailwind.config.ts`.
  - Add global clickable styles: `.btn`, `.btn-primary`, `.btn-outline`, `.link`, and base anchor underline with hover behavior.
  - Convert object detail page and objects index to shadcn token classes.
- Routing/Links
  - Public item links: objects index and admin items list now route names to `/id/[token]` (public view). Edit links remain under `/admin`.
- Search UX/Type safety
  - `NavBarClient.tsx`: typed `ObjectSearchResult`, added error logging, loading state, aria-busy, and shadcn tokens.
  - `app/objects/page.tsx`: remove `any` mappings; stricter transforms; use tokens.
- Logged‑out index polish
  - Add paragraph line break after “private records.”
  - Remove “Explore”; promote “Browse Lookup” and “Log in” to visible buttons.
- Build/CI fixes
  - Force dynamic render for `/objects` to avoid “Missing Supabase env vars” prerender error on CI.
  - Claude Action: pass explicit `github_token` to avoid OIDC JSON parse/bad credentials error.

## Files Touched (high‑level)
- `app/globals.css`
- `tailwind.config.ts`
- `app/objects/page.tsx`
- `app/components/NavBarClient.tsx`
- `app/admin/items/page.tsx`
- `app/id/[token]/page.tsx`
- `.github/workflows/claude.yml` and `claude-code-review.yml`
- `app/page.tsx`

## Accessibility
- Keep sans across body and headings; visible focus and button affordances.
- Search: aria-busy added; keyboard dismiss with Escape preserved.

## Testing
- Local: lint, typecheck, 26 tests, and prod build pass.
- CI: updated workflows to avoid OIDC token errors and prerender env dependency.

## References
- Spec PR and review context: https://github.com/Joi/chanoyu-db/pull/52
- Review comment (link target + token systems + types): https://github.com/Joi/chanoyu-db/pull/52#issuecomment-3247195250
- Failing CI job (prerender env): https://github.com/Joi/chanoyu-db/actions/runs/17419466369/job/49454838455?pr=52

## Checklist
- [x] Sans-serif enforced across key surfaces
- [x] Public item link target corrected
- [x] Type safety and logging improvements
- [x] Global clickable styles added
- [x] Logged‑out index readability improved
- [x] CI builds green locally; workflows adjusted
