### PR TITLE
fix: Correct issue number extraction in PR AC Guard workflow

### DIFF
--- a/.github/workflows/pr-ac-guard.yml
+++ b/.github/workflows/pr-ac-guard.yml
@@ -27,9 +27,13 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const issue_number = core.getInput('issue', { required: true });
+            const issue_number = "${{ steps.refs.outputs.issue }}";
+            if (!issue_number) {
+              core.setFailed("Issue number not extracted from PR body");
+              return;
+            }
             const { data } = await github.rest.issues.get({
-              ...context.repo, issue_number: Number(issue_number || "${{ steps.refs.outputs.issue }}")
+              ...context.repo, issue_number: Number(issue_number)
             });
             return { body: data.body || "" };
           result-encoding: string


### PR DESCRIPTION
## Summary

This PR fixes the PR AC Guard workflow that was failing with "Input required and not supplied: issue" error.

### Problem
The workflow was trying to use `core.getInput('issue', { required: true })` but the issue number is passed via `steps.refs.outputs.issue` from the previous step, not as an input parameter.

### Solution  
- Use `steps.refs.outputs.issue` directly instead of trying to get it as an input
- Add proper error handling if issue number extraction fails
- Maintain same functionality but with correct data flow

### Impact
This will allow PR AC Guard to work correctly for all PRs that contain "Closes #<number>" in their description.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>