### PR TITLE
fix: Return string instead of object from issue body fetch

### DIFF
--- a/.github/workflows/pr-ac-guard.yml
+++ b/.github/workflows/pr-ac-guard.yml
@@ -35,12 +35,12 @@ jobs:
             const { data } = await github.rest.issues.get({
               ...context.repo, issue_number: Number(issue_number)
             });
-            return { body: data.body || "" };
+            return data.body || "";
           result-encoding: string
       - name: Parse AC
         id: parse
         run: |
-          echo '${{ steps.issue.outputs.result }}' | jq -r '.body' > issue_body.txt
+          echo '${{ steps.issue.outputs.result }}' > issue_body.txt
           node -v
           mkdir -p scripts/ac
           cat > scripts/ac/extract-ac.ts <<'TS'


### PR DESCRIPTION
## Summary

This PR fixes the second issue in the PR AC Guard workflow where it was trying to parse "[object Object]" as JSON.

### Problem  
The workflow was returning an object  but then trying to parse it with , which caused a JSON parsing error.

### Solution
- Return  directly as a string instead of wrapping it in an object
- Remove the  parsing since we're already returning the body content

### Impact
The PR AC Guard should now properly parse the issue body content.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>