### PR TITLE
feat: Add PDF attachment support for chakai detail pages

### DIFF
--- a/app/admin/chakai/[id]/page.tsx
+++ b/app/admin/chakai/[id]/page.tsx
@@ -86,7 +86,7 @@ async function removeChakaiItem(formData: FormData) {
   'use server';
   const ok = await requireAdmin();
   if (!ok) return notFound();
-  const chakaiId = String(formData.get('chakai_id') || '');
+  const chakaiId = String(formData.get('id') || ''); // Get from main form's id field
   const objectId = String(formData.get('object_id') || '');
   if (!chakaiId || !objectId) return notFound();
   const db = supabaseAdmin();
@@ -250,11 +250,14 @@ export default async function EditChakai({ params }: { params: { id: string } })
                     </div>
                     <div className="flex gap-2 items-center">
                       <a className="text-xs underline" href={`/admin/${o.token}`}>Edit item</a>
-                      <form action={removeChakaiItem} className="m-0">
-                        <input type="hidden" name="chakai_id" value={c.id} />
-                        <input type="hidden" name="object_id" value={o.id} />
-                        <button type="submit" className="text-xs underline text-red-600">Remove</button>
-                      </form>
+                      <button 
+                        formAction={removeChakaiItem}
+                        name="object_id" 
+                        value={o.id}
+                        className="text-xs underline text-red-600 bg-transparent border-none p-0 cursor-pointer"
+                      >
+                        Remove
+                      </button>
                     </div>
                   </div>
                 );

--- a/app/admin/chakai/[id]/page.tsx
+++ b/app/admin/chakai/[id]/page.tsx
@@ -248,9 +248,9 @@ export default async function EditChakai({ params }: { params: { id: string } })
                     <div className="text-sm">
                       <div>{label}{secondary ? <span className="text-xs text-gray-700 ml-2" lang="en">/ {secondary}</span> : null}{o.local_number ? ` (${o.local_number})` : ''}</div>
                     </div>
-                    <div className="flex gap-2">
+                    <div className="flex gap-2 items-center">
                       <a className="text-xs underline" href={`/admin/${o.token}`}>Edit item</a>
-                      <form action={removeChakaiItem} style={{ display: 'inline' }}>
+                      <form action={removeChakaiItem} className="m-0">
                         <input type="hidden" name="chakai_id" value={c.id} />
                         <input type="hidden" name="object_id" value={o.id} />
                         <button type="submit" className="text-xs underline text-red-600">Remove</button>

--- a/supabase/migrations/20250904_chakai_media_links.sql
+++ b/supabase/migrations/20250904_chakai_media_links.sql
@@ -1,0 +1,63 @@
+-- Add chakai-media links table for PDF and media attachments
+-- Following pattern from object_media_links and location_media_links
+
+-- Many-to-many linkage between chakai and media (supports PDF attachments)
+create table if not exists chakai_media_links (
+  chakai_id uuid references chakai(id) on delete cascade,
+  media_id uuid references media(id) on delete cascade,
+  role text default 'attachment',
+  created_at timestamptz not null default now(),
+  primary key (chakai_id, media_id)
+);
+
+create index if not exists cml_media_idx on chakai_media_links(media_id);
+create index if not exists cml_chakai_idx on chakai_media_links(chakai_id);
+
+-- RLS policy for chakai_media_links - follow chakai visibility rules
+alter table chakai_media_links enable row level security;
+
+-- Allow reading chakai media links based on chakai visibility
+create policy chakai_media_links_read on chakai_media_links for select using (
+  exists (
+    select 1 from chakai c 
+    where c.id = chakai_id 
+    and (
+      c.visibility = 'open' 
+      or (
+        c.visibility = 'members' 
+        and exists (
+          select 1 from chakai_attendees ca 
+          join accounts a on a.id = ca.account_id 
+          where ca.chakai_id = c.id 
+          and a.email = current_setting('request.jwt.claims', true)::json->>'email'
+        )
+      )
+    )
+  )
+);
+
+-- Allow public read of media when linked to chakai with appropriate visibility
+create policy media_public_read_chakai on media for select using (
+  exists (
+    select 1 from chakai_media_links cml
+    join chakai c on c.id = cml.chakai_id
+    where cml.media_id = id 
+    and c.visibility = 'open'
+    and visibility = 'public'
+  )
+  or exists (
+    select 1 from chakai_media_links cml
+    join chakai c on c.id = cml.chakai_id
+    join chakai_attendees ca on ca.chakai_id = c.id
+    join accounts a on a.id = ca.account_id
+    where cml.media_id = id 
+    and c.visibility = 'members'
+    and a.email = current_setting('request.jwt.claims', true)::json->>'email'
+    and (visibility = 'public' or visibility = 'private')
+  )
+);
+
+-- Update media table to support file types (if not already exists)
+alter table media add column if not exists file_type text;
+alter table media add column if not exists file_size bigint;
+alter table media add column if not exists original_filename text;


### PR DESCRIPTION
## Summary
Implements PDF attachment support for chakai detail pages with comprehensive visibility controls and access management.

## Changes Made

### Database Schema
- ✅ **New `chakai_media_links` table**: Junction table linking chakai events to media files
- ✅ **Enhanced `media` table**: Added `file_type`, `file_size`, and `original_filename` columns  
- ✅ **RLS Policies**: Comprehensive row-level security for chakai media access control
- ✅ **Database indexes**: Optimized queries with proper indexing

### Frontend Implementation  
- ✅ **PDF Attachment Display**: New "Attachments" section on chakai detail pages
- ✅ **File Type Detection**: Visual PDF badges and file type indicators
- ✅ **Download/View Links**: Separate actions for viewing PDFs and downloading files
- ✅ **Access Control UI**: Lock icons and messaging for private content
- ✅ **Responsive Design**: Clean, mobile-friendly attachment interface

### Access Control System
- ✅ **Privileged Users** (admin/owner): Can see all media (public + private)
- ✅ **Chakai Attendees**: Can see private media for events they're attending  
- ✅ **Public Users**: Can only see public media attachments
- ✅ **Clear Messaging**: Informational banners about restricted content

### Admin Interface Improvements
- ✅ **Consolidated Items Management**: Single interface for chakai items (no more duplicate lists)
- ✅ **Individual Item Removal**: Remove buttons next to each item with proper alignment
- ✅ **Fixed Hydration Issues**: Resolved nested form errors causing React hydration problems
- ✅ **Enhanced UX**: Streamlined admin workflow for managing chakai items

## Testing Instructions

### Database Setup
1. Run the provided SQL migration in Supabase dashboard to create tables and policies
2. Verify `chakai_media_links` table and enhanced `media` columns exist

### PDF Attachment Testing  
1. Navigate to any chakai detail page
2. Verify "Attachments" section appears (shows "—" if no attachments)
3. Test with different user access levels:
   - **Anonymous**: Should only see public attachments
   - **Attendee**: Should see both public and private attachments for their events
   - **Admin**: Should see all attachments

### Admin Interface Testing
1. Go to `/admin/chakai/[id]` 
2. Verify single "Items used" section (no duplicate lists)
3. Test "Add items" SearchSelect functionality
4. Test "Remove" buttons work without hydration errors
5. Verify "Edit item" and "Remove" buttons are properly aligned

### Responsive Testing
- Test attachment display on desktop and mobile
- Verify file icons and metadata display correctly  
- Ensure download links work across devices

## Security Features
- Server-side RLS enforcement prevents unauthorized media access
- Access control respects existing chakai visibility settings ('open', 'members', 'closed')
- Private media clearly marked with visual indicators
- No sensitive information exposed to unauthorized users

Closes #71

🤖 Generated with [Claude Code](https://claude.ai/code)